### PR TITLE
Get rid of :before

### DIFF
--- a/src/template/stylesheet.css
+++ b/src/template/stylesheet.css
@@ -11,7 +11,7 @@
   font-style: normal;
 }
 
-[data-icon]:before {
+[data-icon] {
   font-family: "<%= folderName %>" !important;
   content: attr(data-icon);
   font-style: normal !important;
@@ -24,8 +24,8 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
-[class^="icon-"]:before,
-[class*=" icon-"]:before {
+[class^="icon-"],
+[class*=" icon-"] {
   font-family: "<%= folderName %>" !important;
   font-style: normal !important;
   font-weight: normal !important;


### PR DESCRIPTION
This causes an issue where a wrapping span tag has its own (likely inherited) `font-size`, and the `::before`'s font size doesn't match, so there is some overlap.

![image](https://cloud.githubusercontent.com/assets/6350157/9259958/d07f40ec-41d2-11e5-9edb-eb4560b59359.png)

The pink is the `::before`, the tan is the `span`, which is inheriting a different `font-family` (in this case, sans-serif) which has a different (total) font height. cf.

![image](https://cloud.githubusercontent.com/assets/6350157/9260007/07f8e2bc-41d3-11e5-96f2-314e2e7aeb0a.png)

Here is a picture after removing the `:before`:

![image](https://cloud.githubusercontent.com/assets/6350157/9260025/2ab6134c-41d3-11e5-84ce-b1e219d85e84.png)
